### PR TITLE
chore: Enable GitHub Pages and verify deployment

### DIFF
--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -23,9 +23,9 @@ Establish the repository, hosting configuration, and file structure.
 - [x] Create `.gitignore` (exclude `snippets/`, `.DS_Store`, OS files)
 - [x] Create `CLAUDE.md` with project-level guidance for Claude Code
 - [x] Create `README.md` with project description and content update instructions
-- [ ] Enable GitHub Pages on the `main` branch
+- [x] Enable GitHub Pages on the `main` branch
 - [x] Create skeleton `index.html` with Tailwind CDN, Alpine.js CDN, and Umami tracking script tags, confirming all load correctly
-- [ ] Verify the site is accessible at `joshukraine.github.io/romans-course/`
+- [x] Verify the site is accessible at `joshukraine.github.io/romans-course/`
 - [ ] Configure custom domain: update Namecheap DNS (A records + CNAME), add `CNAME` file to repo, enable HTTPS in GitHub Pages settings
 - [ ] Verify `joshukraine.com/romans-course/` loads correctly with HTTPS
 


### PR DESCRIPTION
## Summary

- Enable GitHub Pages on the `main` branch, deploying from root `/`
- Verify the skeleton site loads at `https://joshukraine.github.io/romans-course/`

## Changes

- **infra:** Enable GitHub Pages via GitHub API (deploy from `main`, root `/`)
- **docs(roadmap):** Mark "Enable GitHub Pages", "Create skeleton index.html", and "Verify site accessible" as complete in Phase 0

## Testing

- [x] GitHub Pages build completed successfully
- [x] `https://joshukraine.github.io/romans-course/` loads with course title and Tailwind styling applied
- [x] HTTPS enforced on `.github.io` URL

## Notes

This PR contains only the ROADMAP update. The Pages enablement was done via API (`gh api repos/joshukraine/romans-course/pages -X POST`) and is already active. No code changes were needed.

Closes #4