### PR TITLE
docs: Add MIT license for code and copyright notice for course content

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Joshua Steele
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -44,3 +44,12 @@ This opens the site in your default browser and automatically reloads when files
 ## Documentation
 
 Detailed product requirements and implementation roadmap live in `docs/prd/`. Start with [docs/prd/README.md](docs/prd/README.md) for the file index.
+
+## License
+
+This project uses a split license:
+
+- **Code** (HTML, CSS, JavaScript, configuration files): [MIT License](LICENSE)
+- **Course content** (PDF handouts, lecture descriptions, quiz content, course metadata in `course.json`): Copyright (c) 2025 Joshua Steele. All rights reserved.
+
+The hero image is by [Spencer Davis on Unsplash](https://unsplash.com/photos/ilQmlVIMN4c) and is used under the [Unsplash License](https://unsplash.com/license).


### PR DESCRIPTION
## Summary

- Add MIT license file for the code (HTML, CSS, JS, configuration)
- Add License section to README explaining the split license: MIT for code, all rights reserved for course content
- Include Unsplash license attribution for the hero image

## Changes

- **docs:** Create `LICENSE` file with MIT License (copyright 2025 Joshua Steele)
- **docs:** Add License section to `README.md` with split license explanation and Unsplash attribution

## Testing

- [ ] `LICENSE` file renders correctly on GitHub
- [ ] README License section is clear about what's covered by each license

Closes #9