### PR TITLE
chore: Add CNAME file and configure custom domain for GitHub Pages

### DIFF
--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -26,7 +26,7 @@ Establish the repository, hosting configuration, and file structure.
 - [x] Enable GitHub Pages on the `main` branch
 - [x] Create skeleton `index.html` with Tailwind CDN, Alpine.js CDN, and Umami tracking script tags, confirming all load correctly
 - [x] Verify the site is accessible at `joshukraine.github.io/romans-course/`
-- [ ] Configure custom domain: update Namecheap DNS (A records + CNAME), add `CNAME` file to repo, enable HTTPS in GitHub Pages settings
+- [~] Configure custom domain: update Namecheap DNS (A records + CNAME), add `CNAME` file to repo, enable HTTPS in GitHub Pages settings
 - [ ] Verify `joshukraine.com/romans-course/` loads correctly with HTTPS
 
 **PRD references:** `01-overview.md` §Tech Stack; `02-page-layout-and-content.md` §1 "Site Structure", §11 "Custom Domain Configuration"


### PR DESCRIPTION
## Summary

- Add `CNAME` file pointing to `joshukraine.com` for GitHub Pages custom domain
- Set custom domain in GitHub Pages settings via API

## Changes

- **chore:** Create `CNAME` file containing `joshukraine.com`
- **infra:** Configure GitHub Pages custom domain via API
- **docs(roadmap):** Mark custom domain configuration as in progress

## Testing

After DNS is configured at Namecheap and propagates:

- [ ] `https://joshukraine.com/romans-course/` loads the skeleton page
- [ ] `https://www.joshukraine.com/romans-course/` redirects correctly
- [ ] HTTPS is active (padlock icon in browser)
- [ ] `https://joshukraine.com/` shows GitHub's default 404 (expected)

## Notes

This PR covers the repository side of the custom domain setup (CNAME file + GitHub Pages API). The DNS configuration at Namecheap is a manual step:

1. Switch nameservers to Namecheap BasicDNS (if needed)
2. Add A records for `@` → GitHub Pages IPs (185.199.108–111.153)
3. Add CNAME record for `www` → `joshukraine.github.io`
4. Enable "Enforce HTTPS" in GitHub Pages settings after SSL certificate is provisioned

HTTPS enforcement cannot be enabled until DNS points to GitHub and the certificate is issued. The ROADMAP item is marked in-progress (`[~]`) — it will be completed once DNS propagates and HTTPS is verified.

Closes #5