### PR TITLE
chore: Verify custom domain and mark Phase 0 complete

### DIFF
--- a/docs/prd/ROADMAP.md
+++ b/docs/prd/ROADMAP.md
@@ -8,7 +8,7 @@ This document tracks implementation progress through phased delivery. Phases are
 
 | Phase | Name | Dependencies | Status |
 | --- | --- | --- | --- |
-| 0 | Project Foundation | — | Not started |
+| 0 | Project Foundation | — | Complete |
 | 1 | Core Page Structure | Phase 0 | Not started |
 | 2 | Content Population and Launch | Phase 1 | Not started |
 
@@ -26,8 +26,8 @@ Establish the repository, hosting configuration, and file structure.
 - [x] Enable GitHub Pages on the `main` branch
 - [x] Create skeleton `index.html` with Tailwind CDN, Alpine.js CDN, and Umami tracking script tags, confirming all load correctly
 - [x] Verify the site is accessible at `joshukraine.github.io/romans-course/`
-- [~] Configure custom domain: update Namecheap DNS (A records + CNAME), add `CNAME` file to repo, enable HTTPS in GitHub Pages settings
-- [ ] Verify `joshukraine.com/romans-course/` loads correctly with HTTPS
+- [x] Configure custom domain: update Namecheap DNS (A records + CNAME), add `CNAME` file to repo, enable HTTPS in GitHub Pages settings
+- [x] Verify `joshukraine.com/romans-course/` loads correctly with HTTPS
 
 **PRD references:** `01-overview.md` §Tech Stack; `02-page-layout-and-content.md` §1 "Site Structure", §11 "Custom Domain Configuration"
 


### PR DESCRIPTION
## Summary

- Verify custom domain `joshukraine.com` is live with HTTPS enforced
- Mark all Phase 0 roadmap items as complete

## Changes

- **docs(roadmap):** Mark custom domain configuration and HTTPS verification complete; update Phase 0 status to "Complete"

## Testing

- [x] DNS check successful (confirmed in GitHub Pages settings)
- [x] HTTPS enforced (certificate issued by Let's Encrypt, checkbox enabled)
- [x] `https://joshukraine.com/romans-course/` loads correctly
- [x] GitHub API confirms: `https_enforced: true`, `status: built`

Closes #5