### PR TITLE
feat: Add copy-to-clipboard anchor link icon on lecture titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,18 @@
           units: [],
           loading: true,
           error: false,
+          copiedLecture: null,
+          copyLink(lectureNumber) {
+            const url =
+              window.location.origin +
+              window.location.pathname +
+              "#lecture-" +
+              lectureNumber;
+            navigator.clipboard.writeText(url).then(() => {
+              this.copiedLecture = lectureNumber;
+              setTimeout(() => (this.copiedLecture = null), 2000);
+            });
+          },
           dateFmt: new Intl.DateTimeFormat("uk-UA", {
             day: "numeric",
             month: "long",
@@ -484,10 +496,53 @@
                     >
                       <div class="flex items-start justify-between gap-x-4">
                         <div class="min-w-0">
-                          <h3
-                            class="text-base font-semibold text-sand-900 sm:text-lg"
-                            x-text="'Лекція ' + lecture.number + ': ' + lecture.title"
-                          ></h3>
+                          <div class="flex items-center gap-x-2">
+                            <h3
+                              class="text-base font-semibold text-sand-900 sm:text-lg"
+                              x-text="'Лекція ' + lecture.number + ': ' + lecture.title"
+                            ></h3>
+                            <button
+                              type="button"
+                              @click="copyLink(lecture.number)"
+                              class="shrink-0 p-1 text-sand-300 hover:text-sand-500"
+                              :title="copiedLecture === lecture.number ? 'Скопійовано!' : 'Копіювати посилання'"
+                            >
+                              <span class="sr-only">Копіювати посилання</span>
+                              <template
+                                x-if="copiedLecture !== lecture.number"
+                              >
+                                <svg
+                                  viewBox="0 0 20 20"
+                                  fill="currentColor"
+                                  aria-hidden="true"
+                                  class="size-4"
+                                >
+                                  <path
+                                    d="M12.232 4.232a2.5 2.5 0 0 1 3.536 3.536l-1.225 1.224a.75.75 0 0 0 1.061 1.06l1.224-1.224a4 4 0 0 0-5.656-5.656l-3 3a4 4 0 0 0 .225 5.865.75.75 0 0 0 .977-1.138 2.5 2.5 0 0 1-.142-3.667l3-3Z"
+                                  />
+                                  <path
+                                    d="M11.603 7.963a.75.75 0 0 0-.977 1.138 2.5 2.5 0 0 1 .142 3.667l-3 3a2.5 2.5 0 0 1-3.536-3.536l1.225-1.224a.75.75 0 0 0-1.061-1.06l-1.224 1.224a4 4 0 1 0 5.656 5.656l3-3a4 4 0 0 0-.225-5.865Z"
+                                  />
+                                </svg>
+                              </template>
+                              <template
+                                x-if="copiedLecture === lecture.number"
+                              >
+                                <svg
+                                  viewBox="0 0 20 20"
+                                  fill="currentColor"
+                                  aria-hidden="true"
+                                  class="size-4 text-sky-blue-600"
+                                >
+                                  <path
+                                    fill-rule="evenodd"
+                                    d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z"
+                                    clip-rule="evenodd"
+                                  />
+                                </svg>
+                              </template>
+                            </button>
+                          </div>
                           <div
                             class="mt-1 flex flex-wrap items-center gap-x-2 text-sm text-sand-500"
                           >

--- a/index.html
+++ b/index.html
@@ -508,9 +508,7 @@
                               :title="copiedLecture === lecture.number ? 'Скопійовано!' : 'Копіювати посилання'"
                             >
                               <span class="sr-only">Копіювати посилання</span>
-                              <template
-                                x-if="copiedLecture !== lecture.number"
-                              >
+                              <template x-if="copiedLecture !== lecture.number">
                                 <svg
                                   viewBox="0 0 20 20"
                                   fill="currentColor"
@@ -525,9 +523,7 @@
                                   />
                                 </svg>
                               </template>
-                              <template
-                                x-if="copiedLecture === lecture.number"
-                              >
+                              <template x-if="copiedLecture === lecture.number">
                                 <span
                                   class="inline-flex items-center gap-x-1 text-sky-blue-600"
                                 >

--- a/index.html
+++ b/index.html
@@ -504,7 +504,7 @@
                             <button
                               type="button"
                               @click="copyLink(lecture.number)"
-                              class="shrink-0 cursor-pointer p-1 text-sand-300 hover:text-sand-500"
+                              class="shrink-0 cursor-pointer p-1 h-6 text-sand-300 hover:text-sand-500"
                               :title="copiedLecture === lecture.number ? 'Скопійовано!' : 'Копіювати посилання'"
                             >
                               <span class="sr-only">Копіювати посилання</span>

--- a/index.html
+++ b/index.html
@@ -504,7 +504,7 @@
                             <button
                               type="button"
                               @click="copyLink(lecture.number)"
-                              class="shrink-0 p-1 text-sand-300 hover:text-sand-500"
+                              class="shrink-0 cursor-pointer p-1 text-sand-300 hover:text-sand-500"
                               :title="copiedLecture === lecture.number ? 'Скопійовано!' : 'Копіювати посилання'"
                             >
                               <span class="sr-only">Копіювати посилання</span>
@@ -528,18 +528,25 @@
                               <template
                                 x-if="copiedLecture === lecture.number"
                               >
-                                <svg
-                                  viewBox="0 0 20 20"
-                                  fill="currentColor"
-                                  aria-hidden="true"
-                                  class="size-4 text-sky-blue-600"
+                                <span
+                                  class="inline-flex items-center gap-x-1 text-sky-blue-600"
                                 >
-                                  <path
-                                    fill-rule="evenodd"
-                                    d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z"
-                                    clip-rule="evenodd"
-                                  />
-                                </svg>
+                                  <svg
+                                    viewBox="0 0 20 20"
+                                    fill="currentColor"
+                                    aria-hidden="true"
+                                    class="size-4"
+                                  >
+                                    <path
+                                      fill-rule="evenodd"
+                                      d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z"
+                                      clip-rule="evenodd"
+                                    />
+                                  </svg>
+                                  <span class="text-xs font-medium"
+                                    >Скопійовано!</span
+                                  >
+                                </span>
                               </template>
                             </button>
                           </div>


### PR DESCRIPTION
## Summary

- Add a link icon next to each lecture title that copies the full anchor URL to the clipboard
- Visual feedback: icon swaps to a sky-blue checkmark with "Скопійовано!" text for 2 seconds
- Enables easy sharing of direct lecture links in Viber/Telegram

## Changes

- **feat:** Add `copyLink()` method and `copiedLecture` state to the `courseApp` Alpine component
- **feat:** Add chain link icon button (Heroicons) next to each lecture `<h3>` title
- **chore(style):** Add pointer cursor on hover, "Скопійовано!" text alongside checkmark feedback
- **fix:** Fixed-height button (`h-6`) prevents content shift when feedback text appears

## Testing

- [ ] Run `bin/dev` — small link icon visible next to each lecture title (muted sand-300)
- [ ] Hover over icon — cursor changes to pointer, icon darkens to sand-500
- [ ] Click icon — checkmark + "Скопійовано!" appears in sky-blue for 2 seconds, then reverts to link icon
- [ ] Paste clipboard contents — full URL like `http://127.0.0.1:8000/#lecture-3`
- [ ] No content shift when feedback appears/disappears
- [ ] Works on mobile (icon always visible, no hover dependency)

## Notes

- Uses `navigator.clipboard.writeText()` which requires HTTPS or localhost. Works on the production site (`https://joshukraine.com`) and local dev (`http://127.0.0.1`).
- The URL is built from `window.location.origin + window.location.pathname` so it always produces the correct absolute URL regardless of environment.

Closes #36